### PR TITLE
Homework 12: nginx as reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ dbserver ansible_ssh_host=35.195.167.75
 Next edit `environments/stage/group_vars/app` file: replace IP address in variable `db_host` with IP address shown by terraform as `db_internal_ip` (in this example: `db_host: 10.132.0.2`).
 
 
+Then install roles used in playbooks with `ansible-galaxy` utility:
+```
+ansible-galaxy install -r requirements.yml
+```
+
 Run ansible playbooks to deploy on **stage** environment:
 ```
 ansible-playbook site.yml --check

--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -1,7 +1,12 @@
 ---
-- name: Configure application
+- name: Configure application with nginx reverse proxy
   hosts: app
   become: true
 
   roles:
+    - role: jdauphant.nginx
+      nginx_sites:
+        redditapp:
+          - listen 80
+          - location / { proxy_pass http://localhost:9292; }
     - app

--- a/ansible/environments/prod/hosts
+++ b/ansible/environments/prod/hosts
@@ -1,4 +1,4 @@
 [app]
-appserver ansible_ssh_host=35.187.88.162
+appserver ansible_ssh_host=35.190.220.7
 [db]
-dbserver ansible_ssh_host=35.195.101.207
+dbserver ansible_ssh_host=104.155.118.169

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+
+- src: jdauphant.nginx

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -28,12 +28,25 @@ resource "google_compute_address" "app_ip" {
 }
 
 resource "google_compute_firewall" "firewall_puma" {
-  name    = "allow-puma-default80"
+  name    = "allow-puma-default"
   network = "default"
 
   allow {
     protocol = "tcp"
-    ports    = ["9292","80"]
+    ports    = ["9292"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["reddit-app"]
+}
+
+resource "google_compute_firewall" "firewall_http" {
+  name    = "allow-http-default"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
   }
 
   source_ranges = ["0.0.0.0/0"]

--- a/terraform/modules/app/main.tf
+++ b/terraform/modules/app/main.tf
@@ -28,12 +28,12 @@ resource "google_compute_address" "app_ip" {
 }
 
 resource "google_compute_firewall" "firewall_puma" {
-  name    = "allow-puma-default"
+  name    = "allow-puma-default80"
   network = "default"
 
   allow {
     protocol = "tcp"
-    ports    = ["9292"]
+    ports    = ["9292","80"]
   }
 
   source_ranges = ["0.0.0.0/0"]

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,6 +1,7 @@
 provider "google" {
   project = "${var.project}"
   region  = "${var.region}"
+  version = "0.1.3"
 }
 
 module "app" {

--- a/terraform/stage/main.tf
+++ b/terraform/stage/main.tf
@@ -1,6 +1,7 @@
 provider "google" {
   project = "${var.project}"
   region  = "${var.region}"
+  version = "0.1.3"
 }
 
 module "app" {


### PR DESCRIPTION
Выполнил задачу со звёздочкой в ДЗ 12: настроил работу приложения на 80 порту, используя nginx как обратный прокси.
Для этого:
1) конфигурации terraform/modules/app/main.tf открыл 80 порт в firewall
2) в плейбуке ansible/app.yml добавил роль jdauphant.nginx с минимальными настройками `location / { proxy_pass http://localhost:9292; }`

Проверил, реально работает! http://35.190.220.7/

Вопрос: возможно, стоило бы вынести использование роли jdauphant.nginx в отдельный playbook, например nginx.yml?